### PR TITLE
Post service revisions to registry correctly

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: python -m unittest
+        run: poetry run python -m unittest
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,3 +17,30 @@ jobs:
         with:
           path: pyproject.toml
           breaking_change_indicated_by: minor
+
+  run-tests:
+    if: "!contains(github.event.head_commit.message, 'skipci')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3.2
+
+      - name: Check pyproject.toml file
+        run: poetry check
+
+      - name: Run tests
+        run: python -m unittest
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -41,9 +41,3 @@ jobs:
 
       - name: Run tests
         run: poetry run python -m unittest
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: coverage.xml
-          fail_ci_if_error: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Check pyproject.toml file
         run: poetry check
 
+      - name: Install package
+        run: poetry install
+
       - name: Run tests
         run: python -m unittest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "register-service-revision"
-version = "0.1.0"
+version = "0.1.1"
 description = "A GitHub action that registers a revision of an Octue service in a service registry."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"

--- a/register_service_revision/entrypoint.py
+++ b/register_service_revision/entrypoint.py
@@ -2,7 +2,6 @@ import logging
 import sys
 
 import requests
-from requests.compat import urljoin
 
 
 logging.basicConfig(level=logging.INFO)
@@ -26,7 +25,7 @@ def register_service_revision(namespace, name, revision_tag, registry_endpoint):
         registry_endpoint,
     )
 
-    response = requests.post(urljoin(registry_endpoint, f"{namespace}/{name}"), json={"revision_tag": revision_tag})
+    response = requests.post(f"{registry_endpoint.strip('/')}/{namespace}/{name}", json={"revision_tag": revision_tag})
     response.raise_for_status()
 
 

--- a/register_service_revision/entrypoint.py
+++ b/register_service_revision/entrypoint.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 import requests
+from requests.compat import urljoin
 
 
 logging.basicConfig(level=logging.INFO)
@@ -17,9 +18,15 @@ def register_service_revision(namespace, name, revision_tag, registry_endpoint):
     :param str registry_endpoint: the URL of the service registry's service registration endpoint
     :return None:
     """
-    data = {"namespace": namespace, "name": name, "revision_tag": revision_tag}
-    logger.info("Attempting to register service revision %r with registry %r", data, registry_endpoint)
-    response = requests.post(registry_endpoint, json=data)
+    logger.info(
+        "Attempting to register service revision '%s/%s:%s' with registry %r.",
+        namespace,
+        name,
+        revision_tag,
+        registry_endpoint,
+    )
+
+    response = requests.post(urljoin(registry_endpoint, f"{namespace}/{name}"), json={"revision_tag": revision_tag})
     response.raise_for_status()
 
 

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -12,7 +12,7 @@ class TestEntrypoint(unittest.TestCase):
         mock_response = requests.Response()
         mock_response.status_code = 400
 
-        with patch("requests.post", return_value=mock_response):
+        with patch("requests.post", return_value=mock_response) as mock_post:
             with self.assertRaises(requests.exceptions.HTTPError):
                 register_service_revision(
                     namespace="my-org",
@@ -21,15 +21,19 @@ class TestEntrypoint(unittest.TestCase):
                     registry_endpoint="https://blah.com/services",
                 )
 
+        mock_post.assert_called_with("https://blah.com/services/my-org/my-service", json={"revision_tag": "0.1.0"})
+
     def test_successful_registration(self):
         """Test that a successful registration exits gracefully."""
         mock_response = requests.Response()
         mock_response.status_code = 201
 
-        with patch("requests.post", return_value=mock_response):
+        with patch("requests.post", return_value=mock_response) as mock_post:
             register_service_revision(
                 namespace="my-org",
                 name="my-service",
                 revision_tag="0.1.0",
                 registry_endpoint="https://blah.com/services",
             )
+
+        mock_post.assert_called_with("https://blah.com/services/my-org/my-service", json={"revision_tag": "0.1.0"})

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -28,12 +28,17 @@ class TestEntrypoint(unittest.TestCase):
         mock_response = requests.Response()
         mock_response.status_code = 201
 
-        with patch("requests.post", return_value=mock_response) as mock_post:
-            register_service_revision(
-                namespace="my-org",
-                name="my-service",
-                revision_tag="0.1.0",
-                registry_endpoint="https://blah.com/services",
-            )
+        for registry_endpoint in ("https://blah.com/services", "https://blah.com/services/"):
+            with self.subTest(registry_endpoint=registry_endpoint):
+                with patch("requests.post", return_value=mock_response) as mock_post:
+                    register_service_revision(
+                        namespace="my-org",
+                        name="my-service",
+                        revision_tag="0.1.0",
+                        registry_endpoint=registry_endpoint,
+                    )
 
-        mock_post.assert_called_with("https://blah.com/services/my-org/my-service", json={"revision_tag": "0.1.0"})
+                mock_post.assert_called_with(
+                    "https://blah.com/services/my-org/my-service",
+                    json={"revision_tag": "0.1.0"},
+                )


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#1](https://github.com/octue/register-service-revision/pull/1))

### Fixes
- Post service revisions to registry correctly
- Construct post URL correctly

### Operations
- Run tests in CI
- Install package before running tests
- Run tests in poetry environment

### Testing
- Test with registry endpoint ending in trailing slash

<!--- END AUTOGENERATED NOTES --->