### PR TITLE
Allow setting service revisions as default

### DIFF
--- a/.github/workflows/add-issues-to-octue-board.yaml
+++ b/.github/workflows/add-issues-to-octue-board.yaml
@@ -1,0 +1,11 @@
+name: add-issues-to-octue-board
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  add-issues-to-octue-board:
+    uses: octue/.github/.github/workflows/reusable-add-issues-to-octue-board.yaml@main
+    secrets:
+      github-token: ${{ secrets.PROJECT_AUTOMATION_GITHUB_TOKEN_2 }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10.7-slim
 
 # Install via `.zip` file to avoid having to add `git` to image.
-RUN pip install https://github.com/octue/register-service-revision/archive/0.1.1.zip
+RUN pip install https://github.com/octue/register-service-revision/archive/0.2.0.zip
 
 COPY register_service_revision/entrypoint.py /entrypoint.py
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ steps:
     # run: echo "PACKAGE_VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT  <- Use this instead if your package uses a `setup.py` file.
 
   - name: Register service revision
-    uses: octue/register-service-revision@0.1.1
+    uses: octue/register-service-revision@0.2.0
     with:
       service_namespace: my-org
       service_name: my-service

--- a/action.yaml
+++ b/action.yaml
@@ -19,12 +19,17 @@ inputs:
   service_registry_endpoint:
     description: "The HTTP/HTTPS endpoint of the service registry to register the revision in."
     required: true
+  is_default:
+    description: "Whether the revision should be set as the default for its service. If this is unset, the service registry will decide."
+    required: false
+    default: ""
 
 runs:
   using: "docker"
-  image: "docker://octue/register-service-revision:0.1.1"
+  image: "docker://octue/register-service-revision:0.2.0"
   args:
     - ${{ inputs.service_namespace }}
     - ${{ inputs.service_name }}
     - ${{ inputs.service_revision_tag }}
     - ${{ inputs.service_registry_endpoint }}
+    - ${{ inputs.is_default }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "register-service-revision"
-version = "0.1.1"
+version = "0.2.0"
 description = "A GitHub action that registers a revision of an Octue service in a service registry."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"

--- a/register_service_revision/entrypoint.py
+++ b/register_service_revision/entrypoint.py
@@ -8,13 +8,14 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def register_service_revision(namespace, name, revision_tag, registry_endpoint):
+def register_service_revision(namespace, name, revision_tag, registry_endpoint, is_default=None):
     """Register a service revision in the given registry.
 
     :param str namespace: the service namespace
     :param str name: the service name
     :param str revision_tag: the service revision tag
     :param str registry_endpoint: the URL of the service registry's service registration endpoint
+    :param str|None is_default: whether the service revision should be set as the default for its service - should be either the string "true" or "false"
     :return None:
     """
     logger.info(
@@ -25,10 +26,20 @@ def register_service_revision(namespace, name, revision_tag, registry_endpoint):
         registry_endpoint,
     )
 
-    response = requests.post(f"{registry_endpoint.strip('/')}/{namespace}/{name}", json={"revision_tag": revision_tag})
+    body = {"revision_tag": revision_tag}
+
+    if is_default:
+        if is_default.lower() == "true":
+            is_default = True
+        elif is_default.lower() == "false":
+            is_default = False
+
+        body["is_default"] = is_default
+
+    response = requests.post(f"{registry_endpoint.strip('/')}/{namespace}/{name}", json=body)
     response.raise_for_status()
 
 
 if __name__ == "__main__":
-    namespace, name, revision_tag, registry_endpoint = sys.argv[1:5]
-    register_service_revision(namespace, name, revision_tag, registry_endpoint)
+    namespace, name, revision_tag, registry_endpoint, is_default = sys.argv[1:6]
+    register_service_revision(namespace, name, revision_tag, registry_endpoint, is_default)

--- a/register_service_revision/entrypoint.py
+++ b/register_service_revision/entrypoint.py
@@ -35,9 +35,11 @@ def register_service_revision(namespace, name, revision_tag, registry_endpoint, 
             is_default = False
 
         body["is_default"] = is_default
+        logger.info("Setting service revision `is_default=%r`.", is_default)
 
     response = requests.post(f"{registry_endpoint.strip('/')}/{namespace}/{name}", json=body)
     response.raise_for_status()
+    logger.info("Service revision registered successfully.")
 
 
 if __name__ == "__main__":

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -42,3 +42,45 @@ class TestEntrypoint(unittest.TestCase):
                     "https://blah.com/services/my-org/my-service",
                     json={"revision_tag": "0.1.0"},
                 )
+
+    def test_with_is_default_specified_as_true(self):
+        """Test that setting `is_default` as `True` works."""
+        mock_response = requests.Response()
+        mock_response.status_code = 201
+
+        for is_default in ("true", "True", "TRUE"):
+            with self.subTest(is_default=is_default):
+                with patch("requests.post", return_value=mock_response) as mock_post:
+                    register_service_revision(
+                        namespace="my-org",
+                        name="my-service",
+                        revision_tag="0.1.0",
+                        registry_endpoint="https://blah.com/services",
+                        is_default=is_default,
+                    )
+
+                mock_post.assert_called_with(
+                    "https://blah.com/services/my-org/my-service",
+                    json={"revision_tag": "0.1.0", "is_default": True},
+                )
+
+    def test_with_is_default_specified_as_false(self):
+        """Test that setting `is_default` as `False` works."""
+        mock_response = requests.Response()
+        mock_response.status_code = 201
+
+        for is_default in ("false", "False", "FALSE"):
+            with self.subTest(is_default=is_default):
+                with patch("requests.post", return_value=mock_response) as mock_post:
+                    register_service_revision(
+                        namespace="my-org",
+                        name="my-service",
+                        revision_tag="0.1.0",
+                        registry_endpoint="https://blah.com/services",
+                        is_default=is_default,
+                    )
+
+                mock_post.assert_called_with(
+                    "https://blah.com/services/my-org/my-service",
+                    json={"revision_tag": "0.1.0", "is_default": False},
+                )


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#2](https://github.com/octue/register-service-revision/pull/2))

### New features
- Allow setting of `is_default` at service registration

### Enhancements
- Improve logging

### Operations
- Add issues/project workflow

<!--- END AUTOGENERATED NOTES --->